### PR TITLE
add current and new universal resolver contracts, prepare for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           forge soldeer install
 
+      - name: Backup remappings.txt if exists
+        run: |
+          rm -f remappings.txt || true
+          cp remappings-temp.txt remappings.txt || true
+
       - name: Run Forge fmt
         run: |
           forge fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,6 @@ jobs:
         run: |
           forge soldeer install
 
-      - name: Backup remappings.txt if exists
-        run: |
-          rm -f remappings.txt || true
-          cp remappings-temp.txt remappings.txt || true
-
       - name: Run Forge fmt
         run: |
           forge fmt --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Forge build
         run: |
-          forge build --sizes
+          forge build
         id: build
 
       - name: Run Forge tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Show Forge version
         run: |
           forge --version
+      
+      - name: Install dependencies
+        run: |
+          forge soldeer install
 
       - name: Run Forge fmt
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,6 @@ ens-contracts-main = { version = "v1.0.0", git = "https://github.com/ensdomains/
 ens-contracts-urv3 = { version = "v1.0.0", git = "https://github.com/ensdomains/ens-contracts.git", rev = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a" }
 "@openzeppelin/contracts" = { version = "v4.1.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "23869e5b2a7c6b9c3e27dee4289615b8cf50e36b" }
 "@openzeppelin/contracts-sup" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "840c974028316f3c8172c1b8e5ed67ad95e255ca" }
+
+[profile.soldeer]
+remappings_regenerate = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,8 +6,9 @@ libs = ["lib"]
 [dependencies]
 ens-contracts-main = { version = "v1.0.0", git = "https://github.com/ensdomains/ens-contracts.git", rev = "87d8cc5778d483e2b4094868eec0c0cfc9e36a90" }
 ens-contracts-urv3 = { version = "v1.0.0", git = "https://github.com/ensdomains/ens-contracts.git", rev = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a" }
-"@openzeppelin/contracts" = { version = "v4.1.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "23869e5b2a7c6b9c3e27dee4289615b8cf50e36b" }
+"@openzeppelin/contracts" = { version = "v4.8.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "49c0e4370d0cc50ea6090709e3835a3091e33ee2" }
 "@openzeppelin/contracts-sup" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "840c974028316f3c8172c1b8e5ed67ad95e255ca" }
+"@openzeppelin/contracts-upgradeable" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "7f47eb4df9cf70306cc167f4d655275d94dda7cc" }
 
 [profile.soldeer]
 remappings_regenerate = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,5 +10,6 @@ ens-contracts-urv3 = { version = "v1.0.0", git = "https://github.com/ensdomains/
 "@openzeppelin/contracts-sup" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "840c974028316f3c8172c1b8e5ed67ad95e255ca" }
 "@openzeppelin/contracts-upgradeable" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "7f47eb4df9cf70306cc167f4d655275d94dda7cc" }
 
-[profile.soldeer]
+[soldeer]
+remappings_generate = false
 remappings_regenerate = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,8 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
-# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+[dependencies]
+ens-contracts-main = { version = "v1.0.0", git = "https://github.com/ensdomains/ens-contracts.git", rev = "87d8cc5778d483e2b4094868eec0c0cfc9e36a90" }
+ens-contracts-urv3 = { version = "v1.0.0", git = "https://github.com/ensdomains/ens-contracts.git", rev = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a" }
+"@openzeppelin/contracts" = { version = "v4.1.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "23869e5b2a7c6b9c3e27dee4289615b8cf50e36b" }
+"@openzeppelin/contracts-sup" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "840c974028316f3c8172c1b8e5ed67ad95e255ca" }

--- a/remappings-temp.txt
+++ b/remappings-temp.txt
@@ -1,0 +1,4 @@
+@ens-contracts-main=dependencies/ens-contracts-main-v1.0.0
+@ens-contracts-urv3=dependencies/ens-contracts-urv3-v1.0.0
+@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.1.0/contracts
+@openzeppelin/contracts-sup=dependencies/@openzeppelin/contracts-sup-v5.2.0/contracts

--- a/remappings-temp.txt
+++ b/remappings-temp.txt
@@ -1,4 +1,5 @@
 @ens-contracts-main=dependencies/ens-contracts-main-v1.0.0
 @ens-contracts-urv3=dependencies/ens-contracts-urv3-v1.0.0
-@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.1.0/contracts
+@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.8.0/contracts
 @openzeppelin/contracts-sup=dependencies/@openzeppelin/contracts-sup-v5.2.0/contracts
+@openzeppelin/contracts-upgradeable=dependencies/@openzeppelin/contracts-upgradeable-v5.2.0/contracts

--- a/remappings-temp.txt
+++ b/remappings-temp.txt
@@ -1,5 +1,0 @@
-@ens-contracts-main=dependencies/ens-contracts-main-v1.0.0
-@ens-contracts-urv3=dependencies/ens-contracts-urv3-v1.0.0
-@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.8.0/contracts
-@openzeppelin/contracts-sup=dependencies/@openzeppelin/contracts-sup-v5.2.0/contracts
-@openzeppelin/contracts-upgradeable=dependencies/@openzeppelin/contracts-upgradeable-v5.2.0/contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,4 @@
-@openzeppelin/contracts=lib/openzeppelin-contracts/contracts
+@ens-contracts-main=dependencies/ens-contracts-main-v1.0.0
+@ens-contracts-urv3=dependencies/ens-contracts-urv3-v1.0.0
+@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.1.0/contracts
+@openzeppelin/contracts-sup=dependencies/@openzeppelin/contracts-sup-v5.2.0/contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,5 @@
 @ens-contracts-main=dependencies/ens-contracts-main-v1.0.0
 @ens-contracts-urv3=dependencies/ens-contracts-urv3-v1.0.0
-@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.1.0/contracts
+@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.8.0/contracts
 @openzeppelin/contracts-sup=dependencies/@openzeppelin/contracts-sup-v5.2.0/contracts
+@openzeppelin/contracts-upgradeable=dependencies/@openzeppelin/contracts-upgradeable-v5.2.0/contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,5 @@
 @ens-contracts-main=dependencies/ens-contracts-main-v1.0.0
 @ens-contracts-urv3=dependencies/ens-contracts-urv3-v1.0.0
-@openzeppelin/contracts=dependencies/@openzeppelin/contracts-v4.8.0/contracts
-@openzeppelin/contracts-sup=dependencies/@openzeppelin/contracts-sup-v5.2.0/contracts
-@openzeppelin/contracts-upgradeable=dependencies/@openzeppelin/contracts-upgradeable-v5.2.0/contracts
+@openzeppelin/contracts=dependencies/@openzeppelin-contracts-v4.8.0/contracts
+@openzeppelin/contracts-sup=dependencies/@openzeppelin-contracts-sup-v5.2.0/contracts
+@openzeppelin/contracts-upgradeable=dependencies/@openzeppelin-contracts-upgradeable-v5.2.0/contracts

--- a/script/SingleTimeUpgradableProxy.s.sol
+++ b/script/SingleTimeUpgradableProxy.s.sol
@@ -17,7 +17,7 @@ contract SingleTimeUpgradableProxyScript is Script {
         vm.startBroadcast();
 
         universalV1 = new MockUniversalV1();
-        sup = new SingleTimeUpgradableProxy(address(universalV1), ADMIN, "");
+        sup = new SingleTimeUpgradableProxy(ADMIN, address(universalV1), "");
 
         vm.stopBroadcast();
     }

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,30 +1,29 @@
-
-[[dependencies]]
-name = "ens-contracts-main"
-version = "v1.0.0"
-source = "https://github.com/ensdomains/ens-contracts.git"
-checksum = "87d8cc5778d483e2b4094868eec0c0cfc9e36a90"
-
-[[dependencies]]
-name = "ens-contracts-urv3"
-version = "v1.0.0"
-source = "https://github.com/ensdomains/ens-contracts.git"
-checksum = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a"
-
 [[dependencies]]
 name = "@openzeppelin/contracts"
 version = "v4.8.0"
-source = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
-checksum = "49c0e4370d0cc50ea6090709e3835a3091e33ee2"
+git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
+rev = "49c0e4370d0cc50ea6090709e3835a3091e33ee2"
 
 [[dependencies]]
 name = "@openzeppelin/contracts-sup"
 version = "v5.2.0"
-source = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
-checksum = "840c974028316f3c8172c1b8e5ed67ad95e255ca"
+git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
+rev = "840c974028316f3c8172c1b8e5ed67ad95e255ca"
 
 [[dependencies]]
 name = "@openzeppelin/contracts-upgradeable"
 version = "v5.2.0"
-source = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git"
-checksum = "7f47eb4df9cf70306cc167f4d655275d94dda7cc"
+git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git"
+rev = "7f47eb4df9cf70306cc167f4d655275d94dda7cc"
+
+[[dependencies]]
+name = "ens-contracts-main"
+version = "v1.0.0"
+git = "https://github.com/ensdomains/ens-contracts.git"
+rev = "87d8cc5778d483e2b4094868eec0c0cfc9e36a90"
+
+[[dependencies]]
+name = "ens-contracts-urv3"
+version = "v1.0.0"
+git = "https://github.com/ensdomains/ens-contracts.git"
+rev = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a"

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -13,12 +13,18 @@ checksum = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a"
 
 [[dependencies]]
 name = "@openzeppelin/contracts"
-version = "v4.1.0"
+version = "v4.8.0"
 source = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
-checksum = "23869e5b2a7c6b9c3e27dee4289615b8cf50e36b"
+checksum = "49c0e4370d0cc50ea6090709e3835a3091e33ee2"
 
 [[dependencies]]
 name = "@openzeppelin/contracts-sup"
 version = "v5.2.0"
 source = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
 checksum = "840c974028316f3c8172c1b8e5ed67ad95e255ca"
+
+[[dependencies]]
+name = "@openzeppelin/contracts-upgradeable"
+version = "v5.2.0"
+source = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git"
+checksum = "7f47eb4df9cf70306cc167f4d655275d94dda7cc"

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,0 +1,24 @@
+
+[[dependencies]]
+name = "ens-contracts-main"
+version = "v1.0.0"
+source = "https://github.com/ensdomains/ens-contracts.git"
+checksum = "87d8cc5778d483e2b4094868eec0c0cfc9e36a90"
+
+[[dependencies]]
+name = "ens-contracts-urv3"
+version = "v1.0.0"
+source = "https://github.com/ensdomains/ens-contracts.git"
+checksum = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a"
+
+[[dependencies]]
+name = "@openzeppelin/contracts"
+version = "v4.1.0"
+source = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
+checksum = "23869e5b2a7c6b9c3e27dee4289615b8cf50e36b"
+
+[[dependencies]]
+name = "@openzeppelin/contracts-sup"
+version = "v5.2.0"
+source = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"
+checksum = "840c974028316f3c8172c1b8e5ed67ad95e255ca"

--- a/src/SingleTimeUpgradableProxy.sol
+++ b/src/SingleTimeUpgradableProxy.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-sup/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts-sup/proxy/ERC1967/ERC1967Utils.sol";
+import "@openzeppelin/contracts-sup/proxy/utils/Initializable.sol";
 
 contract SingleTimeUpgradableProxy is ERC1967Proxy {
     // Custom storage slot for admin (EIP-1967 compatible)
@@ -61,6 +61,9 @@ contract SingleTimeUpgradableProxy is ERC1967Proxy {
         address previousAdmin = _getAdmin();
         // Bypass ERC1967Utils checks by writing directly to storage
         StorageSlot.getAddressSlot(_ADMIN_SLOT).value = address(0);
+
+        // this can be emitted as well as part of EIP-1967 compatibility
+        // emit IERC1967.AdminChanged(previousAdmin, address(0));
         emit UpgradeRevoked(previousAdmin);
     }
 

--- a/src/SingleTimeUpgradableProxy.sol
+++ b/src/SingleTimeUpgradableProxy.sol
@@ -8,11 +8,9 @@ contract SingleTimeUpgradableProxy is ERC1967Proxy {
     // Custom storage slot for admin (EIP-1967 compatible)
     // ref: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/0d0e4aabdbd6e5994d52048fe42832fc334c6d1f/contracts/proxy/ERC1967/ERC1967Utils.sol#L83C31-L83C41
     bytes32 private constant _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
-    bytes32 private constant _UPGRADED_SLOT = keccak256("SingleTimeUpgradableProxy.upgraded");
 
     // Custom errors
     error CallerNotAdmin();
-    error UpgradeAlreadyPerformed();
     error InvalidImplementation();
     error SameImplementation();
 
@@ -28,12 +26,7 @@ contract SingleTimeUpgradableProxy is ERC1967Proxy {
     }
 
     function upgradeToAndCall(address newImplementation, bytes memory data) external payable onlyAdmin {
-        if (StorageSlot.getBooleanSlot(_UPGRADED_SLOT).value) {
-            revert UpgradeAlreadyPerformed();
-        }
-
         _validateImplementation(newImplementation);
-        StorageSlot.getBooleanSlot(_UPGRADED_SLOT).value = true;
 
         ERC1967Utils.upgradeToAndCall(newImplementation, data);
         _revokeAdmin();

--- a/src/SingleTimeUpgradableProxy.sol
+++ b/src/SingleTimeUpgradableProxy.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts-sup/proxy/ERC1967/ERC1967Proxy.sol";
 import "@openzeppelin/contracts-sup/proxy/ERC1967/ERC1967Utils.sol";
-import "@openzeppelin/contracts-sup/proxy/utils/Initializable.sol";
 
 contract SingleTimeUpgradableProxy is ERC1967Proxy {
     // Custom storage slot for admin (EIP-1967 compatible)
@@ -24,8 +23,8 @@ contract SingleTimeUpgradableProxy is ERC1967Proxy {
         _;
     }
 
-    constructor(address _logic, address _admin, bytes memory _data) ERC1967Proxy(_logic, _data) {
-        ERC1967Utils.changeAdmin(_admin);
+    constructor(address admin_, address logic_, bytes memory data_) ERC1967Proxy(logic_, data_) {
+        ERC1967Utils.changeAdmin(admin_);
     }
 
     function upgradeToAndCall(address newImplementation, bytes memory data) external payable onlyAdmin {

--- a/src/mocks/ENSIP10ResolverFinder.sol
+++ b/src/mocks/ENSIP10ResolverFinder.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {ENS} from "@ens-contracts-urv3/contracts/registry/ENS.sol";
+import {HexUtils} from "@ens-contracts-urv3/contracts/utils/HexUtils.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+abstract contract ENSIP10ResolverFinder is Initializable {
+    using HexUtils for bytes;
+
+    /// @notice The ENS registry.
+    ENS internal _registry;
+
+    /// @notice The name is not encoded correctly.
+    error InvalidNameEncoding();
+
+    /// @notice Sets the ENS registry (upgrade-safe).
+    function __ENSIP10ResolverFinder_init(ENS registry_) internal onlyInitializing {
+        _registry = registry_;
+    }
+
+    /// @notice Finds a resolver by recursively querying the registry, starting at the longest name and progressively
+    /// removing labels until it finds a result.
+    /// @param name The name to resolve, in DNS-encoded and normalised form.
+    /// @return resolver The Resolver responsible for this name.
+    /// @return namehash The namehash of the full name.
+    /// @return finalOffset The offset of the first label with a resolver.
+    function findResolver(
+        bytes calldata name
+    ) public view returns (address resolver, bytes32 namehash, uint256 finalOffset) {
+        return _findResolver(name, 0);
+    }
+
+    /// @dev Finds a resolver recursively based on the offset input.
+    function _findResolver(
+        bytes calldata name,
+        uint256 offset
+    ) internal view returns (address, bytes32, uint256) {
+        uint256 labelLength = uint256(uint8(name[offset]));
+        if (labelLength == 0) {
+            return (address(0), bytes32(0), offset);
+        }
+        uint256 nextLabel = offset + labelLength + 1;
+        if (nextLabel > name.length) revert InvalidNameEncoding();
+
+        bytes32 labelHash;
+        // Check if the label is encoded
+        if (
+            labelLength == 66 &&
+            // 0x5b == '['
+            name[offset + 1] == 0x5b &&
+            // 0x5d == ']'
+            name[nextLabel - 1] == 0x5d
+        ) {
+            // Use the data within the square brackets as the labelhash (i.e. `[...labelhash]`)
+            (labelHash, ) = bytes(name[offset + 2:nextLabel - 1])
+                .hexStringToBytes32(0, 64);
+        } else {
+            labelHash = keccak256(name[offset + 1:nextLabel]);
+        }
+        (
+            address parentresolver,
+            bytes32 parentnode,
+            uint256 parentoffset
+        ) = _findResolver(name, nextLabel);
+        bytes32 node = keccak256(abi.encodePacked(parentnode, labelHash));
+        address resolver = _registry.resolver(node);
+        if (resolver != address(0)) {
+            return (resolver, node, offset);
+        }
+        return (parentresolver, node, parentoffset);
+    }
+}

--- a/src/mocks/ENSIP10ResolverFinder.sol
+++ b/src/mocks/ENSIP10ResolverFinder.sol
@@ -25,17 +25,16 @@ abstract contract ENSIP10ResolverFinder is Initializable {
     /// @return resolver The Resolver responsible for this name.
     /// @return namehash The namehash of the full name.
     /// @return finalOffset The offset of the first label with a resolver.
-    function findResolver(
-        bytes calldata name
-    ) public view returns (address resolver, bytes32 namehash, uint256 finalOffset) {
+    function findResolver(bytes calldata name)
+        public
+        view
+        returns (address resolver, bytes32 namehash, uint256 finalOffset)
+    {
         return _findResolver(name, 0);
     }
 
     /// @dev Finds a resolver recursively based on the offset input.
-    function _findResolver(
-        bytes calldata name,
-        uint256 offset
-    ) internal view returns (address, bytes32, uint256) {
+    function _findResolver(bytes calldata name, uint256 offset) internal view returns (address, bytes32, uint256) {
         uint256 labelLength = uint256(uint8(name[offset]));
         if (labelLength == 0) {
             return (address(0), bytes32(0), offset);
@@ -46,23 +45,16 @@ abstract contract ENSIP10ResolverFinder is Initializable {
         bytes32 labelHash;
         // Check if the label is encoded
         if (
-            labelLength == 66 &&
             // 0x5b == '['
-            name[offset + 1] == 0x5b &&
             // 0x5d == ']'
-            name[nextLabel - 1] == 0x5d
+            labelLength == 66 && name[offset + 1] == 0x5b && name[nextLabel - 1] == 0x5d
         ) {
             // Use the data within the square brackets as the labelhash (i.e. `[...labelhash]`)
-            (labelHash, ) = bytes(name[offset + 2:nextLabel - 1])
-                .hexStringToBytes32(0, 64);
+            (labelHash,) = bytes(name[offset + 2:nextLabel - 1]).hexStringToBytes32(0, 64);
         } else {
             labelHash = keccak256(name[offset + 1:nextLabel]);
         }
-        (
-            address parentresolver,
-            bytes32 parentnode,
-            uint256 parentoffset
-        ) = _findResolver(name, nextLabel);
+        (address parentresolver, bytes32 parentnode, uint256 parentoffset) = _findResolver(name, nextLabel);
         bytes32 node = keccak256(abi.encodePacked(parentnode, labelHash));
         address resolver = _registry.resolver(node);
         if (resolver != address(0)) {

--- a/src/mocks/MockUniversalV1.sol
+++ b/src/mocks/MockUniversalV1.sol
@@ -1,18 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-sup/proxy/utils/Initializable.sol";
 
-contract MockUniversalV1 is Initializable {
+contract MockUniversalV1 {
     uint256 public value;
     address public owner;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
-        _disableInitializers();
-    }
-
-    function initialize() public initializer {
         owner = msg.sender;
     }
 

--- a/src/mocks/UniversalResolverV1.sol
+++ b/src/mocks/UniversalResolverV1.sol
@@ -1,0 +1,686 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.17 <0.9.0;
+
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {LowLevelCallUtils} from "@ens-contracts-main/contracts/utils/LowLevelCallUtils.sol";
+import {ENS} from "@ens-contracts-main/contracts/registry/ENS.sol";
+import {IExtendedResolver} from "@ens-contracts-main/contracts/resolvers/profiles/IExtendedResolver.sol";
+import {Resolver, INameResolver, IAddrResolver} from "@ens-contracts-main/contracts/resolvers/Resolver.sol";
+import {BytesUtils} from "@ens-contracts-main/contracts/utils/BytesUtils.sol";
+import {NameEncoder} from "@ens-contracts-main/contracts/utils/NameEncoder.sol";
+import {HexUtils} from "@ens-contracts-main/contracts/utils/HexUtils.sol";
+
+error OffchainLookup(
+    address sender,
+    string[] urls,
+    bytes callData,
+    bytes4 callbackFunction,
+    bytes extraData
+);
+
+error ResolverNotFound();
+
+error ResolverWildcardNotSupported();
+
+error ResolverNotContract();
+
+error ResolverError(bytes returnData);
+
+error HttpError(HttpErrorItem[] errors);
+
+struct HttpErrorItem {
+    uint16 status;
+    string message;
+}
+
+struct MulticallData {
+    bytes name;
+    bytes[] data;
+    string[] gateways;
+    bytes4 callbackFunction;
+    bool isWildcard;
+    address resolver;
+    bytes metaData;
+    bool[] failures;
+}
+
+struct MulticallChecks {
+    bool isCallback;
+    bool hasExtendedResolver;
+}
+
+struct OffchainLookupCallData {
+    address sender;
+    string[] urls;
+    bytes callData;
+}
+
+struct OffchainLookupExtraData {
+    bytes4 callbackFunction;
+    bytes data;
+}
+
+struct Result {
+    bool success;
+    bytes returnData;
+}
+
+interface BatchGateway {
+    function query(
+        OffchainLookupCallData[] memory data
+    ) external returns (bool[] memory failures, bytes[] memory responses);
+}
+
+/**
+ * The Universal Resolver is a contract that handles the work of resolving a name entirely onchain,
+ * making it possible to make a single smart contract call to resolve an ENS name.
+ */
+contract UniversalResolver is ERC165, OwnableUpgradeable {
+    using Address for address;
+    using NameEncoder for string;
+    using BytesUtils for bytes;
+    using HexUtils for bytes;
+
+    ENS public registry;
+    string[] public batchGatewayURLs;
+
+    function initialize(address _registry, string[] memory _urls) public initializer {
+        __Ownable_init(msg.sender); // Initialize Ownable
+        registry = ENS(_registry);
+        batchGatewayURLs = _urls;
+    }
+
+    function setGatewayURLs(string[] memory _urls) public onlyOwner {
+        batchGatewayURLs = _urls;
+    }
+
+    /**
+     * @dev Performs ENS name resolution for the supplied name and resolution data.
+     * @param name The name to resolve, in normalised and DNS-encoded form.
+     * @param data The resolution data, as specified in ENSIP-10.
+     * @return The result of resolving the name.
+     */
+    function resolve(
+        bytes calldata name,
+        bytes memory data
+    ) external view returns (bytes memory, address) {
+        return
+            _resolveSingle(
+                name,
+                data,
+                batchGatewayURLs,
+                this.resolveSingleCallback.selector,
+                ""
+            );
+    }
+
+    function resolve(
+        bytes calldata name,
+        bytes[] memory data
+    ) external view returns (Result[] memory, address) {
+        return resolve(name, data, batchGatewayURLs);
+    }
+
+    function resolve(
+        bytes calldata name,
+        bytes memory data,
+        string[] memory gateways
+    ) external view returns (bytes memory, address) {
+        return
+            _resolveSingle(
+                name,
+                data,
+                gateways,
+                this.resolveSingleCallback.selector,
+                ""
+            );
+    }
+
+    function resolve(
+        bytes calldata name,
+        bytes[] memory data,
+        string[] memory gateways
+    ) public view returns (Result[] memory, address) {
+        return
+            _resolve(name, data, gateways, this.resolveCallback.selector, "");
+    }
+
+    function _resolveSingle(
+        bytes calldata name,
+        bytes memory data,
+        string[] memory gateways,
+        bytes4 callbackFunction,
+        bytes memory metaData
+    ) public view returns (bytes memory, address) {
+        bytes[] memory dataArr = new bytes[](1);
+        dataArr[0] = data;
+        (Result[] memory results, address resolver) = _resolve(
+            name,
+            dataArr,
+            gateways,
+            callbackFunction,
+            metaData
+        );
+
+        Result memory result = results[0];
+
+        _checkResolveSingle(result);
+
+        return (result.returnData, resolver);
+    }
+
+    function _resolve(
+        bytes calldata name,
+        bytes[] memory data,
+        string[] memory gateways,
+        bytes4 callbackFunction,
+        bytes memory metaData
+    ) internal view returns (Result[] memory results, address resolverAddress) {
+        (Resolver resolver, , uint256 finalOffset) = findResolver(name);
+        resolverAddress = address(resolver);
+        if (resolverAddress == address(0)) {
+            revert ResolverNotFound();
+        }
+
+        if (!resolverAddress.isContract()) {
+            revert ResolverNotContract();
+        }
+
+        bool isWildcard = finalOffset != 0;
+
+        results = _multicall(
+            MulticallData(
+                name,
+                data,
+                gateways,
+                callbackFunction,
+                isWildcard,
+                resolverAddress,
+                metaData,
+                new bool[](data.length)
+            )
+        );
+    }
+
+    function reverse(
+        bytes calldata reverseName
+    ) external view returns (string memory, address, address, address) {
+        return reverse(reverseName, batchGatewayURLs);
+    }
+
+    /**
+     * @dev Performs ENS name reverse resolution for the supplied reverse name.
+     * @param reverseName The reverse name to resolve, in normalised and DNS-encoded form. e.g. b6E040C9ECAaE172a89bD561c5F73e1C48d28cd9.addr.reverse
+     * @return The resolved name, the resolved address, the reverse resolver address, and the resolver address.
+     */
+    function reverse(
+        bytes calldata reverseName,
+        string[] memory gateways
+    ) public view returns (string memory, address, address, address) {
+        bytes memory encodedCall = abi.encodeCall(
+            INameResolver.name,
+            reverseName.namehash(0)
+        );
+        (
+            bytes memory reverseResolvedData,
+            address reverseResolverAddress
+        ) = _resolveSingle(
+                reverseName,
+                encodedCall,
+                gateways,
+                this.reverseCallback.selector,
+                ""
+            );
+
+        return
+            getForwardDataFromReverse(
+                reverseResolvedData,
+                reverseResolverAddress,
+                gateways
+            );
+    }
+
+    function getForwardDataFromReverse(
+        bytes memory resolvedReverseData,
+        address reverseResolverAddress,
+        string[] memory gateways
+    ) internal view returns (string memory, address, address, address) {
+        string memory resolvedName = abi.decode(resolvedReverseData, (string));
+
+        (bytes memory encodedName, bytes32 namehash) = resolvedName
+            .dnsEncodeName();
+
+        bytes memory encodedCall = abi.encodeCall(IAddrResolver.addr, namehash);
+        bytes memory metaData = abi.encode(
+            resolvedName,
+            reverseResolverAddress
+        );
+        (bytes memory resolvedData, address resolverAddress) = this
+            ._resolveSingle(
+                encodedName,
+                encodedCall,
+                gateways,
+                this.reverseCallback.selector,
+                metaData
+            );
+
+        address resolvedAddress = abi.decode(resolvedData, (address));
+
+        return (
+            resolvedName,
+            resolvedAddress,
+            reverseResolverAddress,
+            resolverAddress
+        );
+    }
+
+    function resolveSingleCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    ) external view returns (bytes memory, address) {
+        (Result[] memory results, address resolver, , ) = _resolveCallback(
+            response,
+            extraData,
+            this.resolveSingleCallback.selector
+        );
+        Result memory result = results[0];
+
+        _checkResolveSingle(result);
+
+        return (result.returnData, resolver);
+    }
+
+    function resolveCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    ) external view returns (Result[] memory, address) {
+        (Result[] memory results, address resolver, , ) = _resolveCallback(
+            response,
+            extraData,
+            this.resolveCallback.selector
+        );
+        return (results, resolver);
+    }
+
+    function reverseCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    ) external view returns (string memory, address, address, address) {
+        (
+            Result[] memory results,
+            address resolverAddress,
+            string[] memory gateways,
+            bytes memory metaData
+        ) = _resolveCallback(
+                response,
+                extraData,
+                this.reverseCallback.selector
+            );
+
+        Result memory result = results[0];
+
+        _checkResolveSingle(result);
+
+        if (metaData.length > 0) {
+            (string memory resolvedName, address reverseResolverAddress) = abi
+                .decode(metaData, (string, address));
+            address resolvedAddress = abi.decode(result.returnData, (address));
+            return (
+                resolvedName,
+                resolvedAddress,
+                reverseResolverAddress,
+                resolverAddress
+            );
+        }
+
+        return
+            getForwardDataFromReverse(
+                result.returnData,
+                resolverAddress,
+                gateways
+            );
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IExtendedResolver).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    function _resolveCallback(
+        bytes calldata response,
+        bytes calldata extraData,
+        bytes4 callbackFunction
+    )
+        internal
+        view
+        returns (Result[] memory, address, string[] memory, bytes memory)
+    {
+        MulticallData memory multicallData;
+        multicallData.callbackFunction = callbackFunction;
+        (bool[] memory failures, bytes[] memory responses) = abi.decode(
+            response,
+            (bool[], bytes[])
+        );
+        OffchainLookupExtraData[] memory extraDatas;
+        (
+            multicallData.isWildcard,
+            multicallData.resolver,
+            multicallData.gateways,
+            multicallData.metaData,
+            extraDatas
+        ) = abi.decode(
+            extraData,
+            (bool, address, string[], bytes, OffchainLookupExtraData[])
+        );
+        require(responses.length <= extraDatas.length);
+        multicallData.data = new bytes[](extraDatas.length);
+        multicallData.failures = new bool[](extraDatas.length);
+        uint256 offchainCount = 0;
+        for (uint256 i = 0; i < extraDatas.length; i++) {
+            if (extraDatas[i].callbackFunction == bytes4(0)) {
+                // This call did not require an offchain lookup; use the previous input data.
+                multicallData.data[i] = extraDatas[i].data;
+            } else {
+                if (failures[offchainCount]) {
+                    multicallData.failures[i] = true;
+                    multicallData.data[i] = responses[offchainCount];
+                } else {
+                    multicallData.data[i] = abi.encodeWithSelector(
+                        extraDatas[i].callbackFunction,
+                        responses[offchainCount],
+                        extraDatas[i].data
+                    );
+                }
+                offchainCount = offchainCount + 1;
+            }
+        }
+
+        return (
+            _multicall(multicallData),
+            multicallData.resolver,
+            multicallData.gateways,
+            multicallData.metaData
+        );
+    }
+
+    /**
+     * @dev Makes a call to `target` with `data`. If the call reverts with an `OffchainLookup` error, wraps
+     *      the error with the data necessary to continue the request where it left off.
+     * @param target The address to call.
+     * @param data The data to call `target` with.
+     * @return offchain Whether the call reverted with an `OffchainLookup` error.
+     * @return returnData If `target` did not revert, contains the return data from the call to `target`. Otherwise, contains a `OffchainLookupCallData` struct.
+     * @return extraData If `target` did not revert, is empty. Otherwise, contains a `OffchainLookupExtraData` struct.
+     * @return result Whether the call succeeded.
+     */
+    function callWithOffchainLookupPropagation(
+        address target,
+        bytes memory data,
+        bool isSafe
+    )
+        internal
+        view
+        returns (
+            bool offchain,
+            bytes memory returnData,
+            OffchainLookupExtraData memory extraData,
+            bool result
+        )
+    {
+        if (isSafe) {
+            result = LowLevelCallUtils.functionStaticCall(target, data);
+        } else {
+            result = LowLevelCallUtils.functionStaticCall(target, data, 50000);
+        }
+        uint256 size = LowLevelCallUtils.returnDataSize();
+
+        if (result) {
+            return (
+                false,
+                LowLevelCallUtils.readReturnData(0, size),
+                extraData,
+                true
+            );
+        }
+
+        // Failure
+        if (size >= 4) {
+            bytes memory errorId = LowLevelCallUtils.readReturnData(0, 4);
+            // Offchain lookup. Decode the revert message and create our own that nests it.
+            bytes memory revertData = LowLevelCallUtils.readReturnData(
+                4,
+                size - 4
+            );
+            if (bytes4(errorId) == OffchainLookup.selector) {
+                (
+                    address wrappedSender,
+                    string[] memory wrappedUrls,
+                    bytes memory wrappedCallData,
+                    bytes4 wrappedCallbackFunction,
+                    bytes memory wrappedExtraData
+                ) = abi.decode(
+                        revertData,
+                        (address, string[], bytes, bytes4, bytes)
+                    );
+                if (wrappedSender == target) {
+                    returnData = abi.encode(
+                        OffchainLookupCallData(
+                            wrappedSender,
+                            wrappedUrls,
+                            wrappedCallData
+                        )
+                    );
+                    extraData = OffchainLookupExtraData(
+                        wrappedCallbackFunction,
+                        wrappedExtraData
+                    );
+                    return (true, returnData, extraData, false);
+                }
+            } else {
+                returnData = bytes.concat(errorId, revertData);
+                return (false, returnData, extraData, false);
+            }
+        }
+    }
+
+    /**
+     * @dev Finds a resolver by recursively querying the registry, starting at the longest name and progressively
+     *      removing labels until it finds a result.
+     * @param name The name to resolve, in DNS-encoded and normalised form.
+     * @return resolver The Resolver responsible for this name.
+     * @return namehash The namehash of the full name.
+     * @return finalOffset The offset of the first label with a resolver.
+     */
+    function findResolver(
+        bytes calldata name
+    ) public view returns (Resolver, bytes32, uint256) {
+        (
+            address resolver,
+            bytes32 namehash,
+            uint256 finalOffset
+        ) = findResolver(name, 0);
+        return (Resolver(resolver), namehash, finalOffset);
+    }
+
+    function findResolver(
+        bytes calldata name,
+        uint256 offset
+    ) internal view returns (address, bytes32, uint256) {
+        uint256 labelLength = uint256(uint8(name[offset]));
+        if (labelLength == 0) {
+            return (address(0), bytes32(0), offset);
+        }
+        uint256 nextLabel = offset + labelLength + 1;
+        bytes32 labelHash;
+        if (
+            labelLength == 66 &&
+            // 0x5b == '['
+            name[offset + 1] == 0x5b &&
+            // 0x5d == ']'
+            name[nextLabel - 1] == 0x5d
+        ) {
+            // Encrypted label
+            (labelHash, ) = bytes(name[offset + 2:nextLabel - 1])
+                .hexStringToBytes32(0, 64);
+        } else {
+            labelHash = keccak256(name[offset + 1:nextLabel]);
+        }
+        (
+            address parentresolver,
+            bytes32 parentnode,
+            uint256 parentoffset
+        ) = findResolver(name, nextLabel);
+        bytes32 node = keccak256(abi.encodePacked(parentnode, labelHash));
+        address resolver = registry.resolver(node);
+        if (resolver != address(0)) {
+            return (resolver, node, offset);
+        }
+        return (parentresolver, node, parentoffset);
+    }
+
+    function _checkInterface(
+        address resolver,
+        bytes4 interfaceId
+    ) internal view returns (bool) {
+        try
+            Resolver(resolver).supportsInterface{gas: 50000}(interfaceId)
+        returns (bool supported) {
+            return supported;
+        } catch {
+            return false;
+        }
+    }
+
+    function _checkSafetyAndItem(
+        bytes memory name,
+        bytes memory item,
+        address resolver,
+        MulticallChecks memory multicallChecks
+    ) internal view returns (bool, bytes memory) {
+        if (!multicallChecks.isCallback) {
+            if (multicallChecks.hasExtendedResolver) {
+                return (
+                    true,
+                    abi.encodeCall(IExtendedResolver.resolve, (name, item))
+                );
+            }
+            return (_checkInterface(resolver, bytes4(item)), item);
+        }
+        return (true, item);
+    }
+
+    function _checkMulticall(
+        MulticallData memory multicallData
+    ) internal view returns (MulticallChecks memory) {
+        bool isCallback = multicallData.name.length == 0;
+        bool hasExtendedResolver = _checkInterface(
+            multicallData.resolver,
+            type(IExtendedResolver).interfaceId
+        );
+
+        if (multicallData.isWildcard && !hasExtendedResolver) {
+            revert ResolverWildcardNotSupported();
+        }
+
+        return MulticallChecks(isCallback, hasExtendedResolver);
+    }
+
+    function _checkResolveSingle(Result memory result) internal pure {
+        if (!result.success) {
+            if (bytes4(result.returnData) == HttpError.selector) {
+                bytes memory returnData = result.returnData;
+                assembly {
+                    revert(add(returnData, 32), mload(returnData))
+                }
+            }
+            revert ResolverError(result.returnData);
+        }
+    }
+
+    function _multicall(
+        MulticallData memory multicallData
+    ) internal view returns (Result[] memory results) {
+        uint256 length = multicallData.data.length;
+        uint256 offchainCount = 0;
+        OffchainLookupCallData[]
+            memory callDatas = new OffchainLookupCallData[](length);
+        OffchainLookupExtraData[]
+            memory extraDatas = new OffchainLookupExtraData[](length);
+        results = new Result[](length);
+        MulticallChecks memory multicallChecks = _checkMulticall(multicallData);
+
+        for (uint256 i = 0; i < length; i++) {
+            bytes memory item = multicallData.data[i];
+            bool failure = multicallData.failures[i];
+
+            if (failure) {
+                results[i] = Result(false, item);
+                continue;
+            }
+
+            bool isSafe = false;
+            (isSafe, item) = _checkSafetyAndItem(
+                multicallData.name,
+                item,
+                multicallData.resolver,
+                multicallChecks
+            );
+
+            (
+                bool offchain,
+                bytes memory returnData,
+                OffchainLookupExtraData memory extraData,
+                bool success
+            ) = callWithOffchainLookupPropagation(
+                    multicallData.resolver,
+                    item,
+                    isSafe
+                );
+
+            if (offchain) {
+                callDatas[offchainCount] = abi.decode(
+                    returnData,
+                    (OffchainLookupCallData)
+                );
+                extraDatas[i] = extraData;
+                offchainCount += 1;
+                continue;
+            }
+
+            if (success && multicallChecks.hasExtendedResolver) {
+                // if this is a successful resolve() call, unwrap the result
+                returnData = abi.decode(returnData, (bytes));
+            }
+            results[i] = Result(success, returnData);
+            extraDatas[i].data = item;
+        }
+
+        if (offchainCount == 0) {
+            return results;
+        }
+
+        // Trim callDatas if offchain data exists
+        assembly {
+            mstore(callDatas, offchainCount)
+        }
+
+        revert OffchainLookup(
+            address(this),
+            multicallData.gateways,
+            abi.encodeWithSelector(BatchGateway.query.selector, callDatas),
+            multicallData.callbackFunction,
+            abi.encode(
+                multicallData.isWildcard,
+                multicallData.resolver,
+                multicallData.gateways,
+                multicallData.metaData,
+                extraDatas
+            )
+        );
+    }
+}

--- a/src/mocks/UniversalResolverV2.sol
+++ b/src/mocks/UniversalResolverV2.sol
@@ -1,0 +1,763 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import {PrefixlessHexUtils} from "@ens-contracts-urv3/contracts/utils/PrefixlessHexUtils.sol";
+import {ENS} from "@ens-contracts-urv3/contracts/registry/ENS.sol";
+import {IMulticallGateway} from "@ens-contracts-urv3/contracts/universalResolver/IMulticallGateway.sol";
+import {IBatchGateway} from "@ens-contracts-urv3/contracts/universalResolver/IBatchGateway.sol";
+import {ERC3668Multicallable} from "@ens-contracts-urv3/contracts/universalResolver/ERC3668Multicallable.sol";
+import {ERC3668Caller} from "@ens-contracts-urv3/contracts/universalResolver/ERC3668Caller.sol";
+// import {ENSIP10ResolverFinder} from "@ens-contracts-urv3/contracts/universalResolver/ENSIP10ResolverFinder.sol";
+import {ENSIP10ResolverFinder} from "./ENSIP10ResolverFinder.sol";
+import {IExtendedResolver} from "@ens-contracts-urv3/contracts/resolvers/profiles/IExtendedResolver.sol";
+import {OffchainLookupData} from "@ens-contracts-urv3/contracts/utils/ERC3668Utils.sol";
+import {LowLevelCallUtils} from "@ens-contracts-urv3/contracts/utils/LowLevelCallUtils.sol";
+import {INameResolver} from "@ens-contracts-urv3/contracts/resolvers/profiles/INameResolver.sol";
+import {IAddrResolver} from "@ens-contracts-urv3/contracts/resolvers/profiles/IAddrResolver.sol";
+import {IAddressResolver} from "@ens-contracts-urv3/contracts/resolvers/profiles/IAddressResolver.sol";
+import {NameEncoder} from "@ens-contracts-urv3/contracts/utils/NameEncoder.sol";
+import {IUniversalResolver} from "@ens-contracts-urv3/contracts/universalResolver/IUniversalResolver.sol";
+
+//                                             ENS:E   ENS
+//                                         ENS:ENS:     ENS:EN
+//                                     ENS:ENS:ENS       ENS:ENS:
+//                                 ENS:ENS:ENS:E           ENS:ENS:EN
+//                              ENS:ENS:ENS:ENS             ENS:ENS:ENS:
+//                           ENS:ENS:ENS:ENS:                 ENS:ENS:ENS:EN
+//                        ENS:ENS:ENS:ENS:EN                    ENS:ENS:ENS:ENS
+//                     ENS:ENS:ENS:ENS:ENS                       ENS:ENS:ENS:ENS:EN
+//                  ENS:ENS:ENS:ENS:ENS:E                          ENS:ENS:ENS:ENS:ENS
+//                ENS:ENS:ENS:ENS:ENS:E                              ENS:ENS:ENS:ENS:ENS:
+//              ENS:ENS:ENS:ENS:ENS:EN                                ENS:ENS:ENS:ENS:ENS:E
+//            ENS:ENS:ENS:ENS:ENS:EN                                    ENS:ENS:ENS:ENS:ENS:E
+//           ENS:ENS:ENS:ENS:ENS:EN                                      ENS:ENS:ENS:ENS:ENS:EN
+//           ENS:ENS:ENS:ENS:ENS:                                          ENS:ENS:ENS:ENS:ENS:E
+//          ENS:ENS:ENS:ENS:ENS:                                            ENS:ENS:ENS:ENS:ENS:E
+//          ENS:ENS:ENS:ENS:EN                                                ENS:ENS:ENS:ENS:ENS:E
+//   ENS    ENS:ENS:ENS:ENS:E                                                  ENS:ENS:ENS:ENS:ENS:E
+//   ENS     ENS:ENS:ENS:EN                                                      ENS:ENS:ENS:ENS:ENS:
+//  ENS:E    ENS:ENS:ENS:E                                                         ENS:ENS:ENS:ENS:EN
+// ENS:ENS    ENS:ENS:EN                                                            ENS:ENS:ENS:ENS:EN
+// ENS:ENS:     ENS:ENS                                                               ENS:ENS:ENS:ENS:
+// ENS:ENS:E     ENS:                                                                  ENS:ENS:ENS:ENS:
+// ENS:ENS:ENS                                                                           ENS:ENS:ENS:EN
+// ENS:ENS:ENS:                                                                            ENS:ENS:ENS:
+// ENS:ENS:ENS:EN                                                                           ENS:ENS:ENS
+// ENS:ENS:ENS:ENS:                                                                 ENS:     ENS:ENS:EN
+// ENS:ENS:ENS:ENS:E                                                               ENS:ENS     ENS:ENS:
+//  ENS:ENS:ENS:ENS:E                                                             ENS:ENS:E     ENS:EN
+//  ENS:ENS:ENS:ENS:ENS                                                         ENS:ENS:ENS:     ENS:E
+//   ENS:ENS:ENS:ENS:ENS:                                                      ENS:ENS:ENS:EN     ENS
+//    ENS:ENS:ENS:ENS:ENS:                                                   ENS:ENS:ENS:ENS:     ENS
+//     ENS:ENS:ENS:ENS:ENS:E                                                ENS:ENS:ENS:ENS:EN
+//      ENS:ENS:ENS:ENS:ENS:EN                                            ENS:ENS:ENS:ENS:ENS:
+//        ENS:ENS:ENS:ENS:ENS:E                                          ENS:ENS:ENS:ENS:ENS:
+//         ENS:ENS:ENS:ENS:ENS:EN                                      ENS:ENS:ENS:ENS:ENS:EN
+//           ENS:ENS:ENS:ENS:ENS:E                                    ENS:ENS:ENS:ENS:ENS:E
+//             ENS:ENS:ENS:ENS:ENS:E                                ENS:ENS:ENS:ENS:ENS:EN
+//               ENS:ENS:ENS:ENS:ENS:                              ENS:ENS:ENS:ENS:ENS:E
+//                  ENS:ENS:ENS:ENS:ENS                          ENS:ENS:ENS:ENS:ENS:E
+//                     ENS:ENS:ENS:ENS:EN                       ENS:ENS:ENS:ENS:ENS
+//                        ENS:ENS:ENS:ENS:                    ENS:ENS:ENS:ENS:EN
+//                            ENS:ENS:ENS:EN                 ENS:ENS:ENS:ENS:
+//                               ENS:ENS:ENS:              ENS:ENS:ENS:ENS
+//                                   ENS:ENS:EN           ENS:ENS:ENS:
+//                                      ENS:ENS:E       ENS:ENS:ENS
+//                                         ENS:ENS     ENS:ENS:
+//                                             ENS:   ENS:
+
+/// @title UniversalResolver
+/// @notice The universal entrypoint for ENS resolution.
+contract UniversalResolver is
+    IUniversalResolver,
+    ERC3668Multicallable,
+    ERC3668Caller,
+    ENSIP10ResolverFinder,
+    ERC165,
+    OwnableUpgradeable
+{
+    /// @notice Batch gateway URLs to use for offchain resolution.
+    ///         Gateways should implement IBatchGateway.
+    string[] public _urls;
+    /// @notice The SLIP44 most-significant bit for EVM chains.
+    ///         See ENSIP-11 for reference: https://docs.ens.domains/ensip/11
+    uint256 private constant SLIP44_MSB = 0x80000000;
+
+    /// @notice Sets the batch gateway URLs and ENS registry.
+    /// @param registry_ The ENS registry.
+    /// @param urls_ The batch gateway URLs.
+    function initialize(address registry_, string[] memory urls_) public reinitializer(2) {
+        __Ownable_init(msg.sender);
+        ENSIP10ResolverFinder(registry_);
+        _urls = urls_;
+    }
+
+    /// @notice Sets the batch gateway URLs.
+    /// @param urls_ The batch gateway URLs.
+    function setUrls(string[] memory urls_) external onlyOwner {
+        _urls = urls_;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                RESOLVE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IUniversalResolver
+    function resolve(
+        bytes calldata name,
+        bytes calldata data
+    )
+        external
+        view
+        returns (bytes memory /* result */, address /* resolver */)
+    {
+        resolveWithGateways(name, data, _urls);
+    }
+
+    /// @notice Performs ENS name resolution for the supplied name, resolution data, and batch gateway URLs.
+    /// @param name The name to resolve, in normalised and DNS-encoded form.
+    /// @param data The resolution data, as specified in ENSIP-10.
+    ///             For a multicall, the data should be encoded as `(bytes[])`.
+    /// @param gateways The batch gateway URLs to use for offchain resolution.
+    ///                 Gateways should implement IBatchGateway.
+    /// @return result The result of the resolution.
+    ///                For a multicall, the result is encoded as `(bytes[])`.
+    /// @return resolver The resolver that was used to resolve the name.
+    function resolveWithGateways(
+        bytes calldata name,
+        bytes calldata data,
+        string[] memory gateways
+    ) public view returns (bytes memory /* result */, address resolver) {
+        uint256 finalOffset;
+        (resolver, , finalOffset) = findResolver(name);
+
+        if (resolver == address(0)) revert ResolverNotFound(name);
+        if (!Address.isContract(resolver)) revert ResolverNotContract(name);
+
+        bool isWildcard = finalOffset != 0;
+        bool isExtendedResolver = _checkInterface(
+            resolver,
+            type(IExtendedResolver).interfaceId
+        );
+
+        if (isWildcard && !isExtendedResolver) revert ResolverNotFound(name);
+
+        bool isSingleInternallyEncodedCall = bytes4(data) !=
+            IMulticallGateway.multicall.selector;
+        bytes[] memory calls;
+
+        if (isSingleInternallyEncodedCall) {
+            calls = new bytes[](1);
+            calls[0] = data;
+        } else {
+            calls = abi.decode(data[4:], (bytes[]));
+        }
+
+        if (isExtendedResolver)
+            _attemptResolveMulticall(
+                name,
+                calls,
+                resolver,
+                gateways,
+                isSingleInternallyEncodedCall
+            );
+
+        _internalMulticall(
+            name,
+            calls,
+            resolver,
+            gateways,
+            isSingleInternallyEncodedCall,
+            isExtendedResolver
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                REVERSE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IUniversalResolver
+    function reverse(
+        bytes memory lookupAddress,
+        uint256 coinType
+    )
+        public
+        view
+        returns (
+            string memory /* name */,
+            address /* resolver */,
+            address /* reverseResolver */
+        )
+    {
+        reverseWithGateways(lookupAddress, coinType, _urls);
+    }
+
+    /// @notice Performs ENS reverse resolution for the supplied address, coin type, and batch gateway URLs.
+    /// @param lookupAddress The address to reverse resolve, in encoded form.
+    /// @param coinType The coin type to use for the reverse resolution.
+    ///                 For ETH, this is 60.
+    ///                 For other EVM chains, coinType is calculated as `0x80000000 | chainId`.
+    /// @param gateways The batch gateway URLs to use for offchain resolution.
+    ///                 Gateways should implement IBatchGateway.
+    /// @return name The reverse resolution result.
+    /// @return resolver The resolver that was used to resolve the name.
+    /// @return reverseResolver The resolver that was used to resolve the reverse name.
+    function reverseWithGateways(
+        bytes memory lookupAddress,
+        uint256 coinType,
+        string[] memory gateways
+    )
+        public
+        view
+        returns (
+            string memory /* name */,
+            address /* resolver */,
+            address /* reverseResolver */
+        )
+    {
+        (bytes memory reverseName, bytes32 reverseNamehash) = NameEncoder
+            .dnsEncodeName(_createReverseNode(lookupAddress, coinType));
+        bytes memory nameCall = abi.encodeWithSelector(
+            INameResolver.name.selector,
+            reverseNamehash
+        );
+        bytes memory encodedCall = abi.encodeWithSelector(
+            this.resolveWithGateways.selector,
+            reverseName,
+            nameCall,
+            gateways
+        );
+
+        call(
+            address(this),
+            0,
+            encodedCall,
+            abi.encode(lookupAddress, coinType, gateways),
+            this._forwardLookupReverseCallback.selector,
+            bytes4(0)
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            RESOLVE MULTICALL
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Creates a call to resolve a name using an extended resolver.
+    function _createResolveMulticall(
+        bytes calldata name,
+        bytes[] memory calls
+    ) internal pure returns (bytes memory) {
+        return
+            abi.encodeWithSelector(
+                IExtendedResolver.resolve.selector,
+                name,
+                abi.encodeWithSelector(
+                    IMulticallGateway.multicall.selector,
+                    calls
+                )
+            );
+    }
+
+    /// @dev Attempts to resolve a name with `resolve(multicall(calls))` using `call`.
+    ///      Will fallback to `_internalMulticall` if it fails
+    function _attemptResolveMulticall(
+        bytes calldata name,
+        bytes[] memory calls,
+        address resolver,
+        string[] memory gateways,
+        bool isSingleInternallyEncodedCall
+    ) internal view {
+        call(
+            resolver,
+            0,
+            _createResolveMulticall(name, calls),
+            abi.encode(
+                name,
+                calls,
+                resolver,
+                gateways,
+                isSingleInternallyEncodedCall
+            ),
+            this._resolveMulticallResolveCallback.selector,
+            this._resolveMulticallResolveFailureCallback.selector
+        );
+    }
+
+    /// @dev Callback for resolving a name with `resolve(multicall(calls))` using `call`.
+    ///      Is only called if the call to `resolve(multicall(calls))` fails.
+    /// @notice This function should never be called directly.
+    function _resolveMulticallResolveFailureCallback(
+        bytes calldata /* response */,
+        bytes calldata extraData
+    ) external view {
+        (
+            bytes memory name,
+            bytes[] memory calls,
+            address resolver,
+            string[] memory gateways,
+            bool isSingleInternallyEncodedCall
+        ) = abi.decode(extraData, (bytes, bytes[], address, string[], bool));
+
+        _internalMulticall(
+            name,
+            calls,
+            resolver,
+            gateways,
+            isSingleInternallyEncodedCall,
+            true
+        );
+    }
+
+    /// @dev Callback for resolving a name with `resolve(multicall(calls))` using `call`.
+    /// @notice This function should never be called directly.
+    function _resolveMulticallResolveCallback(
+        bytes calldata encodedResponse,
+        bytes calldata extraData
+    ) external pure returns (bytes memory response, address resolver) {
+        response = abi.decode(encodedResponse, (bytes));
+        bool isSingleInternallyEncodedCall;
+        (, , resolver, , isSingleInternallyEncodedCall) = abi.decode(
+            extraData,
+            (bytes, bytes[], address, string[], bool)
+        );
+
+        if (isSingleInternallyEncodedCall) {
+            response = _resultFromSingleInternallyEncodedCall(response, false);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            INTERNAL MULTICALL
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Creates a call to resolve a name with `multicall(calls)` or `multicall(...resolve(name, call))`.
+    ///      A call is made to `multicall` on this contract, which is possible since it extends `ERC3668Multicallable`.
+    ///      Calls are also wrapped in `_internalCall`, which routes all the external calls through this contract
+    ///      meaning that a batch gateway can be used (via calldata rewriting in `_internalCallCalldataRewrite`).
+    function _createInternalMulticall(
+        bytes memory name,
+        bytes[] memory calls,
+        address resolver,
+        string[] memory gateways,
+        bool isExtendedResolver
+    ) internal view returns (bytes memory) {
+        for (uint256 i = 0; i < calls.length; i++) {
+            bool isSafe;
+            if (isExtendedResolver) {
+                // extended resolver calls need to be wrapped with `resolve(name, call)`
+                calls[i] = _encodeCallWithResolve(name, calls[i]);
+                // extended resolver calls are assumed safe because they are
+                // almost definitely all deployed with solidity > 0.4.11
+                // (also we can't check that the interface is supported)
+                isSafe = true;
+            } else {
+                // this is required to prevent calls from using all the gas
+                // if it reverts (solidity < 0.4.11)
+                isSafe = _checkInterface(resolver, bytes4(calls[i]));
+            }
+            calls[i] = abi.encodeWithSelector(
+                this._internalCall.selector,
+                resolver,
+                calls[i],
+                // 50k gas is arbitrary, but should be more than enough where required
+                isSafe ? 0 : 50000
+            );
+        }
+
+        return abi.encodeWithSelector(this.multicall.selector, calls, gateways);
+    }
+
+    /// @dev Resolves a name with `multicall(calls)` or `multicall(...resolve(name, call))`.
+    function _internalMulticall(
+        bytes memory name,
+        bytes[] memory calls,
+        address resolver,
+        string[] memory gateways,
+        bool isSingleInternallyEncodedCall,
+        bool isExtendedResolver
+    ) internal view {
+        call(
+            address(this),
+            0,
+            _createInternalMulticall(
+                name,
+                calls,
+                resolver,
+                gateways,
+                isExtendedResolver
+            ),
+            abi.encode(
+                resolver,
+                isSingleInternallyEncodedCall,
+                isExtendedResolver
+            ),
+            this._internalMulticallResolveCallback.selector,
+            bytes4(0)
+        );
+    }
+
+    /// @dev Callback for resolving a name with `multicall(calls)` or `multicall(...resolve(name, call))`.
+    /// @notice This function should never be called directly.
+    function _internalMulticallResolveCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    ) external pure returns (bytes memory result, address resolver) {
+        bool isSingleInternallyEncodedCall;
+        bool isExtendedResolver;
+        (resolver, isSingleInternallyEncodedCall, isExtendedResolver) = abi
+            .decode(extraData, (address, bool, bool));
+
+        if (isSingleInternallyEncodedCall)
+            return (
+                _resultFromSingleInternallyEncodedCall(
+                    response,
+                    isExtendedResolver
+                ),
+                resolver
+            );
+
+        if (isExtendedResolver) {
+            bytes[] memory results = abi.decode(response, (bytes[]));
+            for (uint256 i = 0; i < results.length; i++) {
+                results[i] = _decodeExtendedResolverResult(results[i]);
+            }
+            return (abi.encode(results), resolver);
+        }
+
+        // this is more efficient than just returning the response
+        // idk why, but saves 21 gas!
+        result = response;
+        return (result, resolver);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            REVERSE CALLBACKS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Callback for resolving `addr(bytes32, uint256)` based on the name
+    ///      from reverse resolution. For ETH, there is a fallback to
+    ///      `addr(bytes32)` if the `addr(bytes32, uint256)` call reverts.
+    /// @notice This function should never be called directly.
+    function _forwardLookupReverseCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    ) external view {
+        (
+            bytes memory lookupAddress,
+            uint256 coinType,
+            string[] memory gateways
+        ) = abi.decode(extraData, (bytes, uint256, string[]));
+        (bytes memory result, address reverseResolver) = abi.decode(
+            response,
+            (bytes, address)
+        );
+        string memory resolvedName = abi.decode(result, (string));
+        (bytes memory encodedName, bytes32 namehash) = NameEncoder
+            .dnsEncodeName(resolvedName);
+        bytes memory addrCall = abi.encodeWithSelector(
+            IAddressResolver.addr.selector,
+            namehash,
+            coinType
+        );
+        bytes memory encodedCall = abi.encodeWithSelector(
+            this.resolveWithGateways.selector,
+            encodedName,
+            addrCall,
+            gateways
+        );
+        call(
+            address(this),
+            0,
+            encodedCall,
+            abi.encode(
+                lookupAddress,
+                coinType,
+                gateways,
+                resolvedName,
+                reverseResolver,
+                false // isAddrCall (i.e. `addr(bytes32)`)
+            ),
+            this._processLookupReverseCallback.selector,
+            // for ETH coinType, fallback to `addr(bytes32)` on failure
+            coinType == 60
+                ? this._attemptAddrResolverReverseCallback.selector
+                : bytes4(0)
+        );
+    }
+
+    /// @dev Callback for attempting a fallback to `addr(bytes32)` if
+    ///      `addr(bytes32, uint256)` reverts.
+    /// @notice This function should never be called directly.
+    function _attemptAddrResolverReverseCallback(
+        bytes calldata /* response */,
+        bytes calldata extraData
+    ) external view {
+        (
+            bytes memory lookupAddress,
+            uint256 coinType,
+            string[] memory gateways,
+            string memory resolvedName,
+            address reverseResolver,
+
+        ) = abi.decode(
+                extraData,
+                (bytes, uint256, string[], string, address, bool)
+            );
+        (bytes memory encodedName, bytes32 namehash) = NameEncoder
+            .dnsEncodeName(resolvedName);
+        bytes memory addrCall = abi.encodeWithSelector(
+            IAddrResolver.addr.selector,
+            namehash
+        );
+        bytes memory encodedCall = abi.encodeWithSelector(
+            this.resolveWithGateways.selector,
+            encodedName,
+            addrCall,
+            gateways
+        );
+        call(
+            address(this),
+            0,
+            encodedCall,
+            abi.encode(
+                lookupAddress,
+                coinType,
+                gateways,
+                resolvedName,
+                reverseResolver,
+                true // isAddrCall (i.e. `addr(bytes32)`)
+            ),
+            this._processLookupReverseCallback.selector,
+            bytes4(0)
+        );
+    }
+
+    /// @dev Callback for handling the result from reverse resolution.
+    /// @notice This function should never be called directly.
+    function _processLookupReverseCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    )
+        external
+        pure
+        returns (string memory name, address resolver, address reverseResolver)
+    {
+        bytes memory lookupAddress;
+        bytes memory result;
+        uint256 coinType;
+        bool isAddrCall;
+        (lookupAddress, coinType, , name, reverseResolver, isAddrCall) = abi
+            .decode(
+                extraData,
+                (bytes, uint256, string[], string, address, bool)
+            );
+        (result, resolver) = abi.decode(response, (bytes, address));
+        // for `addr(bytes32)` the result needs to be unwrapped to a left-padded bytes32
+        result = isAddrCall
+            ? abi.encodePacked(abi.decode(result, (address)))
+            : abi.decode(result, (bytes));
+        if (_isEvmChain(coinType)) {
+            address resolvedAddress = _bytesToAddress(result);
+            address decodedLookupAddress = _bytesToAddress(lookupAddress);
+            if (resolvedAddress != decodedLookupAddress) {
+                revert ReverseAddressMismatch(
+                    abi.encodePacked(resolvedAddress)
+                );
+            }
+        } else {
+            if (keccak256(result) != keccak256(lookupAddress)) {
+                revert ReverseAddressMismatch(result);
+            }
+        }
+        return (name, resolver, reverseResolver);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            INTERNAL CALL
+    //////////////////////////////////////////////////////////////*/
+
+    function validateLookupResponse(
+        bytes calldata response,
+        bytes4 internalCallbackFunction
+    ) internal pure override {
+        if (internalCallbackFunction != this._internalCallCallback.selector)
+            return;
+        if (bytes4(response) == HttpError.selector)
+            LowLevelCallUtils.propagateRevert(response);
+    }
+
+    function lookupCalldataRewrite(
+        OffchainLookupData memory lookupData,
+        bytes4 internalCallbackFunction
+    ) internal pure override returns (bytes memory) {
+        if (internalCallbackFunction != this._internalCallCallback.selector)
+            return "";
+        return
+            abi.encodeWithSelector(
+                IBatchGateway.query.selector,
+                lookupData.sender,
+                lookupData.urls,
+                lookupData.callData
+            );
+    }
+
+    /// @dev Callback for handling a single internal call.
+    ///      Just returns the response directly since no validation is needed.
+    /// @notice This function should never be called directly.
+    function _internalCallCallback(
+        bytes memory response,
+        bytes calldata /* extraData */
+    ) external pure {
+        assembly {
+            return(add(response, 32), mload(response))
+        }
+    }
+
+    /// @dev Routes an internal call through this contract.
+    ///      This allows rewriting for BatchGateway, and also validating the
+    ///      response to ensure it's not an HTTP error.
+    /// @notice This function should never be called directly.
+    function _internalCall(
+        address target,
+        bytes calldata data,
+        uint256 gas
+    ) external view {
+        call(
+            target,
+            gas,
+            data,
+            "",
+            this._internalCallCallback.selector,
+            bytes4(0)
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Encodes a call with `resolve(name, call)`.
+    function _encodeCallWithResolve(
+        bytes memory name,
+        bytes memory data
+    ) internal pure returns (bytes memory) {
+        return abi.encodeCall(IExtendedResolver.resolve, (name, data));
+    }
+
+    /// @dev Checks if a result is empty.
+    function _isEmptyResult(uint256 resultLength) internal pure returns (bool) {
+        return resultLength == 0;
+    }
+
+    /// @dev Checks if a result is an error.
+    function _isErrorResult(uint256 resultLength) internal pure returns (bool) {
+        return resultLength % 32 == 4;
+    }
+
+    /// @dev Decodes a result from an extended resolver.
+    ///      This is required since all extended resolver calls are
+    ///      wrapped in `resolve(name, call)`, which returns `bytes`.
+    ///      `bytes` should be unwrapped to get the actual result,
+    ///      but if the result is an error or empty, it needs to be
+    ///      left as is since it can't be decoded. For a client,
+    ///      this is fine since they will handle error/empty results
+    ///      anyway.
+    function _decodeExtendedResolverResult(
+        bytes memory result
+    ) internal pure returns (bytes memory) {
+        if (_isEmptyResult(result.length)) return result;
+        if (_isErrorResult(result.length)) return result;
+        return abi.decode(result, (bytes));
+    }
+
+    /// @dev Decodes a result from a single internally encoded call.
+    ///      This is required since the default encoding assumes a multicall,
+    ///      so it needs to be unwrapped. Or, if the result is an error,
+    ///      it needs to be propagated directly.
+    function _resultFromSingleInternallyEncodedCall(
+        bytes memory result,
+        bool shouldDecodeResult
+    ) internal pure returns (bytes memory) {
+        bytes[] memory results = abi.decode(result, (bytes[]));
+        bytes memory item = results[0];
+
+        if (_isEmptyResult(item.length) || _isErrorResult(item.length)) {
+            if (bytes4(item) == HttpError.selector)
+                LowLevelCallUtils.propagateRevert(item);
+
+            revert ResolverError(item);
+        }
+
+        if (shouldDecodeResult) return abi.decode(item, (bytes));
+
+        return item;
+    }
+
+    /// @dev Checks if a resolver supports an interface.
+    function _checkInterface(
+        address resolver,
+        bytes4 interfaceId
+    ) internal view returns (bool) {
+        try
+            ERC165(resolver).supportsInterface{gas: 50000}(interfaceId)
+        returns (bool supported) {
+            return supported;
+        } catch {
+            return false;
+        }
+    }
+
+    /// @dev Creates the DNS-encoded reverse name for a given address and coin type.
+    ///      For ETH, this is `[address].addr.reverse`
+    ///      Example: 0x123...456 => 123...456.addr.reverse
+    ///      For other coinTypes, this is `[address].[coinType].reverse`
+    ///      EVM chain example: 0x123...456, 0x8000000a => 123...456.8000000a.reverse
+    ///      Non-EVM chain example: 0x123...456, 0x1fa => 123...456.01fa.reverse
+    function _createReverseNode(
+        bytes memory lookupAddress,
+        uint256 coinType
+    ) internal pure returns (string memory) {
+        return
+            string(
+                bytes.concat(
+                    PrefixlessHexUtils.toHexString(lookupAddress),
+                    ".",
+                    coinType == 60
+                        ? bytes("addr")
+                        : PrefixlessHexUtils.toHexString(coinType),
+                    ".reverse"
+                )
+            );
+    }
+
+    /// @dev Checks if a coin type is for an EVM chain.
+    function _isEvmChain(uint256 coinType) internal pure returns (bool) {
+        if (coinType == 60) return true;
+        return (coinType & SLIP44_MSB) != 0;
+    }
+
+    /// @dev Converts a bytes value to an address.
+    function _bytesToAddress(bytes memory b) internal pure returns (address a) {
+        require(b.length == 20);
+        assembly {
+            a := div(mload(add(b, 32)), exp(256, 12))
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                ERC165
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IUniversalResolver).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+}

--- a/test/SUPwithUniversalResolver.t.sol
+++ b/test/SUPwithUniversalResolver.t.sol
@@ -27,11 +27,7 @@ contract ProxyTest is Test {
         urV1 = new UniversalResolverV1();
         urV2 = new UniversalResolverV2();
 
-        bytes memory initData = abi.encodeWithSelector(
-            UniversalResolverV1.initialize.selector, 
-            ens, 
-            urls
-        );
+        bytes memory initData = abi.encodeWithSelector(UniversalResolverV1.initialize.selector, ens, urls);
         vm.prank(ADMIN);
         proxy = new SingleTimeUpgradableProxy(ADMIN, address(urV1), initData);
     }
@@ -62,11 +58,7 @@ contract ProxyTest is Test {
     function test_SuccessfulUpgrade() public {
         string[] memory urls = new string[](1);
         urls[0] = "https://test1";
-        bytes memory initData = abi.encodeWithSelector(
-            UniversalResolverV1.initialize.selector, 
-            ens, 
-            urls
-        );
+        bytes memory initData = abi.encodeWithSelector(UniversalResolverV1.initialize.selector, ens, urls);
         vm.prank(ADMIN);
         proxy.upgradeToAndCall(address(urV2), initData);
 
@@ -95,11 +87,7 @@ contract ProxyTest is Test {
         string[] memory urls = new string[](1);
         urls[0] = "http://universal-offchain-resolver.local";
 
-        bytes memory initDataV1 = abi.encodeWithSelector(
-            UniversalResolverV1.initialize.selector, 
-            ens, 
-            urls
-        );
+        bytes memory initDataV1 = abi.encodeWithSelector(UniversalResolverV1.initialize.selector, ens, urls);
         vm.prank(ADMIN);
         SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(ADMIN, address(urV1), initDataV1);
 
@@ -110,11 +98,7 @@ contract ProxyTest is Test {
         vm.prank(ADMIN);
         proxyV1.setGatewayURLs(urls);
 
-        bytes memory initData = abi.encodeWithSelector(
-            UniversalResolverV1.initialize.selector, 
-            ens, 
-            urls
-        );
+        bytes memory initData = abi.encodeWithSelector(UniversalResolverV1.initialize.selector, ens, urls);
 
         vm.prank(ADMIN);
         proxyTemp.upgradeToAndCall(address(urV2), initData);

--- a/test/SUPwithUniversalResolver.t.sol
+++ b/test/SUPwithUniversalResolver.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/SingleTimeUpgradableProxy.sol";
+
+import {UniversalResolver as UniversalResolverV1} from "@ens-contracts-main/contracts/utils/UniversalResolver.sol";
+import {UniversalResolver as UniversalResolverV2} from "@ens-contracts-urv3/contracts/universalResolver/UniversalResolver.sol";
+import {ENS} from "@ens-contracts-urv3/contracts/registry/ENS.sol";
+
+import {Create2} from "@openzeppelin/contracts-sup/utils/Create2.sol";
+
+contract ProxyTest is Test {
+    address constant ADMIN = address(0x123);
+    address constant USER = address(0x456);
+    address constant STRANGER = address(0x789);
+
+    SingleTimeUpgradableProxy proxy;
+    UniversalResolverV1 urV1;
+    UniversalResolverV2 urV2;
+
+    ENS ens = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+
+    function setUp() public {
+        string[] memory urls = new string[](1);
+        urls[0] = "http://universal-offchain-resolver.local";
+
+        urV1 = UniversalResolverV1(0xce01f8eee7E479C928F8919abD53E553a36CeF67);
+        vm.prank(ADMIN);
+        urV2 = new UniversalResolverV2(ens, urls);
+
+        // // Deploy through proxy to preserve msg.sender as ADMIN
+        // vm.startBroadcast(ADMIN);
+        // bytes memory constructorArgs = abi.encode(ens, urls);
+        // bytes memory bytecode = abi.encodePacked(
+        //     type(UniversalResolverV2).creationCode,
+        //     constructorArgs
+        // );
+        // bytes32 salt = bytes32(0);
+        // urV2 = UniversalResolverV2(Create2.deploy(0, salt, bytecode));
+        // vm.stopBroadcast();
+
+        proxy = new SingleTimeUpgradableProxy(address(urV1), ADMIN, "");
+    }
+
+    /////// Core Functionality Tests ///////
+    function test_InitialState() public view {
+        assertEq(proxy.admin(), ADMIN);
+        assertEq(proxy.implementation(), address(urV1));
+
+        UniversalResolverV1 proxyV1 = UniversalResolverV1(address(proxy));
+        assertEq(proxyV1.owner(), address(0));
+    }
+
+    function test_ProxyFunctionality() public {
+        UniversalResolverV1 proxyV1 = UniversalResolverV1(address(proxy));
+
+        string[] memory urls = new string[](1);
+        urls[0] = "https://test1";
+        vm.prank(proxyV1.owner());
+        proxyV1.setGatewayURLs(urls);
+
+        assertEq(proxyV1.batchGatewayURLs(0), urls[0]);
+    }
+
+    /////// Upgrade Tests ///////
+    function test_SuccessfulUpgrade() public {
+        vm.prank(ADMIN);
+        proxy.upgradeToAndCall(address(urV2), "");
+
+        assertEq(proxy.implementation(), address(urV2));
+        assertEq(proxy.admin(), address(0));
+        
+        UniversalResolverV2 upgraded = UniversalResolverV2(address(proxy));
+
+        string[] memory urls = new string[](1);
+        urls[0] = "https://test1";
+
+        console.log("urV2 - owner");
+        console.logAddress(urV2.owner());
+        console.log("urV2 - address");
+        console.logAddress(address(urV2));
+        console.log("implementation address");
+        console.logAddress(proxy.implementation());
+        console.log("upgraded - owner");
+        console.logAddress(upgraded.owner());
+
+        vm.prank(ADMIN);
+        upgraded.setUrls(urls);
+        assertEq(upgraded._urls(0), urls[0]);
+    }
+
+    function test_StoragePersistanceAfterUpgrade() public {
+        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(
+            address(urV1),
+            ADMIN,
+            ""
+        );
+
+        UniversalResolverV1 proxyV1 = UniversalResolverV1(address(proxyTemp));
+        UniversalResolverV2 proxyV2 = UniversalResolverV2(address(proxyTemp));
+
+        string[] memory urls = new string[](1);
+        urls[0] = "https://test1";
+        vm.prank(proxyV1.owner());
+        proxyV1.setGatewayURLs(urls);
+
+        vm.prank(ADMIN);
+        proxyTemp.upgradeToAndCall(address(urV2), "");
+        assertEq(proxyV2._urls(0), urls[0]);
+    }
+}

--- a/test/SUPwithUniversalResolver.t.sol
+++ b/test/SUPwithUniversalResolver.t.sol
@@ -5,7 +5,8 @@ import "forge-std/Test.sol";
 import "../src/SingleTimeUpgradableProxy.sol";
 
 import {UniversalResolver as UniversalResolverV1} from "@ens-contracts-main/contracts/utils/UniversalResolver.sol";
-import {UniversalResolver as UniversalResolverV2} from "@ens-contracts-urv3/contracts/universalResolver/UniversalResolver.sol";
+import {UniversalResolver as UniversalResolverV2} from
+    "@ens-contracts-urv3/contracts/universalResolver/UniversalResolver.sol";
 import {ENS} from "@ens-contracts-urv3/contracts/registry/ENS.sol";
 
 import {Create2} from "@openzeppelin/contracts-sup/utils/Create2.sol";
@@ -70,7 +71,7 @@ contract ProxyTest is Test {
 
         assertEq(proxy.implementation(), address(urV2));
         assertEq(proxy.admin(), address(0));
-        
+
         UniversalResolverV2 upgraded = UniversalResolverV2(address(proxy));
 
         string[] memory urls = new string[](1);
@@ -91,11 +92,7 @@ contract ProxyTest is Test {
     }
 
     function test_StoragePersistanceAfterUpgrade() public {
-        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(
-            address(urV1),
-            ADMIN,
-            ""
-        );
+        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(address(urV1), ADMIN, "");
 
         UniversalResolverV1 proxyV1 = UniversalResolverV1(address(proxyTemp));
         UniversalResolverV2 proxyV2 = UniversalResolverV2(address(proxyTemp));

--- a/test/SingleTimeUpgradableProxy.t.sol
+++ b/test/SingleTimeUpgradableProxy.t.sol
@@ -21,8 +21,7 @@ contract ProxyTest is Test {
         v2 = new MockUniversalV2();
         v2Bad = new MockUniversalV2();
 
-        bytes memory initData = abi.encodeCall(MockUniversalV1.initialize, ());
-        proxy = new SingleTimeUpgradableProxy(address(v1), ADMIN, initData);
+        proxy = new SingleTimeUpgradableProxy(address(v1), ADMIN, "");
     }
 
     /////// Core Functionality Tests ///////
@@ -31,7 +30,7 @@ contract ProxyTest is Test {
         assertEq(proxy.implementation(), address(v1));
 
         MockUniversalV1 proxyV1 = MockUniversalV1(address(proxy));
-        assertEq(proxyV1.owner(), address(this));
+        assertEq(proxyV1.owner(), address(0));
     }
 
     function test_ProxyFunctionality() public {
@@ -57,8 +56,7 @@ contract ProxyTest is Test {
     }
 
     function test_StoragePersistanceAfterUpgrade() public {
-        bytes memory initData = abi.encodeCall(MockUniversalV1.initialize, ());
-        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(address(v1), ADMIN, initData);
+        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(address(v1), ADMIN, "");
 
         MockUniversalV1 proxyV1 = MockUniversalV1(address(proxyTemp));
         MockUniversalV2 proxyV2 = MockUniversalV2(address(proxyTemp));
@@ -106,10 +104,5 @@ contract ProxyTest is Test {
         bytes32 adminSlot = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
         address currentAdmin = address(uint160(uint256(vm.load(address(proxy), adminSlot))));
         assertEq(currentAdmin, address(0));
-    }
-
-    function test_CannotInitializeImplementation() public {
-        vm.expectRevert(bytes4(keccak256("InvalidInitialization()")));
-        MockUniversalV1(address(v1)).initialize();
     }
 }

--- a/test/SingleTimeUpgradableProxy.t.sol
+++ b/test/SingleTimeUpgradableProxy.t.sol
@@ -21,7 +21,7 @@ contract ProxyTest is Test {
         v2 = new MockUniversalV2();
         v2Bad = new MockUniversalV2();
 
-        proxy = new SingleTimeUpgradableProxy(address(v1), ADMIN, "");
+        proxy = new SingleTimeUpgradableProxy(ADMIN, address(v1), "");
     }
 
     /////// Core Functionality Tests ///////
@@ -56,7 +56,7 @@ contract ProxyTest is Test {
     }
 
     function test_StoragePersistanceAfterUpgrade() public {
-        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(address(v1), ADMIN, "");
+        SingleTimeUpgradableProxy proxyTemp = new SingleTimeUpgradableProxy(ADMIN, address(v1), "");
 
         MockUniversalV1 proxyV1 = MockUniversalV1(address(proxyTemp));
         MockUniversalV2 proxyV2 = MockUniversalV2(address(proxyTemp));

--- a/test/SingleTimeUpgradableProxy.t.sol
+++ b/test/SingleTimeUpgradableProxy.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
+import "@openzeppelin/contracts-sup/interfaces/IERC1967.sol";
 import "../src/SingleTimeUpgradableProxy.sol";
 import "../src/mocks/MockUniversalV1.sol";
 import "../src/mocks/MockUniversalV2.sol";
@@ -94,6 +95,16 @@ contract ProxyTest is Test {
         vm.prank(ADMIN);
         vm.expectRevert(SingleTimeUpgradableProxy.InvalidImplementation.selector);
         proxy.upgradeToAndCall(STRANGER, "");
+    }
+
+    function test_UpgradeEmitsRevocationEvent() public {
+        vm.expectEmit(true, true, false, true);
+        emit IERC1967.Upgraded(address(v2));
+        vm.expectEmit(true, true, false, true);
+        emit SingleTimeUpgradableProxy.UpgradeRevoked(ADMIN);
+
+        vm.prank(ADMIN);
+        proxy.upgradeToAndCall(address(v2), "");
     }
 
     /////// Edge Cases ///////


### PR DESCRIPTION
There are couple of changes needed on both UniversalResolver implementations before proceeding further;

- Storage Layout of current Universal Resolver and the new implementation doesn't match.
While current storage layout of Universal Resolver is;

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| 0   | _owner             | address     | (From Ownable) |
| 1    | batchGatewayURLs   | string[]    | |
| 2    | registry           | address     |  |

For universal v2;

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| 0   | _owner             | address     | (From Ownable) |
| 1    | registry           | address     | (From ENSIP10ResolverFinder)  |
| 2    | urls   | string[]    |  |

which causes a storage collusion.


- Ownable module is incompatible with the Upgradable pattern

It sets the ownership at deployment time, while the implementation storage keeps the owner info, the proxy storage doesn't have access to same information. instead I used OwnableUpgradable, we can decouple the initialization, allow proxy to set ownership in proxy storage.

Both issues are addressed in the pull request. New storage layout;

### UniversalResolver V1

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| [INITIALIZABLE](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/930598edfb6241a179ade6ad44ba59ed8b68f7d8/contracts/proxy/utils/Initializable.sol#L77C30-L77C51) | _initialized       | uint8       | (From Initializable) |
| [OWNABLE](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/8ab1f5acf958b937531cee87f99ae4c0242f0dee/contracts/access/OwnableUpgradeable.sol#L28) | _owner             | address     | (From OwnableUpgradeable) |
| 0    | registry           | address     |  |
| 1    | batchGatewayURLs   | string[]    | |


### UniversalResolver V2

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| [INITIALIZABLE](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/930598edfb6241a179ade6ad44ba59ed8b68f7d8/contracts/proxy/utils/Initializable.sol#L77C30-L77C51) | _initialized       | uint8       | (From Initializable) |
| [OWNABLE](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/8ab1f5acf958b937531cee87f99ae4c0242f0dee/contracts/access/OwnableUpgradeable.sol#L28) | _owner             | address     | (From OwnableUpgradeable) |
| 0    | registry           | address     | (From ENSIP10ResolverFinder)  |
| 1    | urls   | string[]    |  |