### PR TITLE
add universal resolver v3, refactor for upgrade pattern

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,8 @@ ens-contracts-urv3 = { version = "v1.0.0", git = "https://github.com/ensdomains/
 "@openzeppelin/contracts" = { version = "v4.8.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "49c0e4370d0cc50ea6090709e3835a3091e33ee2" }
 "@openzeppelin/contracts-sup" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git", rev = "840c974028316f3c8172c1b8e5ed67ad95e255ca" }
 "@openzeppelin/contracts-upgradeable" = { version = "v5.2.0", git = "https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable.git", rev = "7f47eb4df9cf70306cc167f4d655275d94dda7cc" }
+"unruggable-labs/unruggable-resolve" = { version = "1.0.0", git = "https://github.com/unruggable-labs/unruggable-resolve.git", rev = "431e321cad7f2bd5644dd8cf816b1084e3e7cc2f" }
+"unruggable-labs/CCIPReader.sol" = { version = "1.0.0", git = "https://github.com/unruggable-labs/CCIPReader.sol.git", rev = "341576fe7ff2b6e0c93fc08f37740cf6439f5873" }
 
 [soldeer]
 remappings_generate = false

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,3 +3,5 @@
 @openzeppelin/contracts=dependencies/@openzeppelin-contracts-v4.8.0/contracts
 @openzeppelin/contracts-sup=dependencies/@openzeppelin-contracts-sup-v5.2.0/contracts
 @openzeppelin/contracts-upgradeable=dependencies/@openzeppelin-contracts-upgradeable-v5.2.0/contracts
+@unruggable-labs/contracts=dependencies/unruggable-labs-unruggable-resolve-1.0.0/contracts
+@unruggable-labs/ccip-reader=dependencies/unruggable-labs-CCIPReader.sol-1.0.0

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -27,3 +27,15 @@ name = "ens-contracts-urv3"
 version = "v1.0.0"
 git = "https://github.com/ensdomains/ens-contracts.git"
 rev = "9a89be3d31ccb1f4d0e9c6c5a2e2ededf3aa990a"
+
+[[dependencies]]
+name = "unruggable-labs/CCIPReader.sol"
+version = "1.0.0"
+git = "https://github.com/unruggable-labs/CCIPReader.sol.git"
+rev = "341576fe7ff2b6e0c93fc08f37740cf6439f5873"
+
+[[dependencies]]
+name = "unruggable-labs/unruggable-resolve"
+version = "1.0.0"
+git = "https://github.com/unruggable-labs/unruggable-resolve.git"
+rev = "431e321cad7f2bd5644dd8cf816b1084e3e7cc2f"

--- a/src/mocks/UniversalResolverV3.sol
+++ b/src/mocks/UniversalResolverV3.sol
@@ -14,7 +14,6 @@ import {DNSCoder} from "@unruggable-labs/contracts/DNSCoder.sol";
 contract UniversalResolver is CCIPReader, OwnableUpgradeable, IUniversalResolver {
     IReverseUR public rr;
     string[] public __urls; // keeping urls slot reserved for the removal
-    
 
     function initialize(IReverseUR _rr) public reinitializer(2) {
         __Ownable_init(msg.sender);

--- a/src/mocks/UniversalResolverV3.sol
+++ b/src/mocks/UniversalResolverV3.sol
@@ -13,6 +13,8 @@ import {DNSCoder} from "@unruggable-labs/contracts/DNSCoder.sol";
 
 contract UniversalResolver is CCIPReader, OwnableUpgradeable, IUniversalResolver {
     IReverseUR public rr;
+    string[] public __urls; // keeping urls slot reserved for the removal
+    
 
     function initialize(IReverseUR _rr) public reinitializer(2) {
         __Ownable_init(msg.sender);

--- a/src/mocks/UniversalResolverV3.sol
+++ b/src/mocks/UniversalResolverV3.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// equivalent to: https://github.com/ensdomains/ens-contracts/blob/feat/universalresolver-3/contracts/universalResolver/UniversalResolver.sol
+
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {CCIPReader} from "@unruggable-labs/ccip-reader/contracts/CCIPReader.sol";
+import {IUR, Lookup, Response, ResponseBits} from "@unruggable-labs/contracts/IUR.sol";
+import {IReverseUR} from "@unruggable-labs/contracts/IReverseUR.sol";
+import {IResolveMulticall} from "@unruggable-labs/contracts/IResolveMulticall.sol";
+import {IUniversalResolver} from "@unruggable-labs/contracts/IUniversalResolver.sol";
+import {DNSCoder} from "@unruggable-labs/contracts/DNSCoder.sol";
+
+contract UniversalResolver is CCIPReader, OwnableUpgradeable, IUniversalResolver {
+    IReverseUR public rr;
+
+    function initialize(IReverseUR _rr) public reinitializer(2) {
+        __Ownable_init(msg.sender);
+        rr = _rr;
+    }
+
+    function resolve(bytes calldata name, bytes memory data) external view returns (bytes memory, address) {
+        return resolveWithGateways(name, data, new string[](0));
+    }
+
+    function resolveWithGateways(bytes memory name, bytes memory data, string[] memory gateways)
+        public
+        view
+        returns (bytes memory, address)
+    {
+        bytes[] memory calls;
+        bool multi = bytes4(data) == IResolveMulticall.multicall.selector;
+        if (multi) {
+            assembly {
+                mstore(add(data, 4), sub(mload(data), 4)) // drop selector
+                data := add(data, 4)
+            }
+            calls = abi.decode(data, (bytes[]));
+        } else {
+            calls = new bytes[](1);
+            calls[0] = data;
+        }
+        bytes memory v = ccipRead(
+            address(rr.ur()),
+            abi.encodeCall(IUR.resolve, (name, calls, gateways)),
+            this.resolveWithGatewaysCallback.selector,
+            abi.encode(multi)
+        );
+        assembly {
+            return(add(v, 32), mload(v))
+        }
+    }
+
+    function resolveWithGatewaysCallback(bytes memory ccip, bytes memory carry)
+        external
+        view
+        returns (bytes memory answer, address resolver)
+    {
+        (Lookup memory lookup, Response[] memory res) = abi.decode(ccip, (Lookup, Response[]));
+        resolver = _extractResolver(lookup);
+        bool multi = abi.decode(carry, (bool));
+        if (multi) {
+            bytes[] memory m = new bytes[](res.length);
+            for (uint256 i; i < res.length; i++) {
+                m[i] = res[i].data;
+            }
+            answer = abi.encode(m);
+        } else {
+            answer = res[0].data;
+            if ((res[0].bits & ResponseBits.ERROR) != 0) {
+                revert ResolverError(answer);
+            }
+        }
+    }
+
+    function reverse(bytes calldata lookupAddress, uint256 coinType)
+        external
+        view
+        returns (string memory, address, address)
+    {
+        return reverseWithGateways(lookupAddress, coinType, new string[](0));
+    }
+
+    function reverseWithGateways(bytes calldata lookupAddress, uint256 coinType, string[] memory gateways)
+        public
+        view
+        returns (string memory, address, address)
+    {
+        bytes memory v = ccipRead(
+            address(rr),
+            abi.encodeCall(IReverseUR.reverse, (lookupAddress, coinType, gateways)),
+            this.reverseWithGatewaysCallback.selector,
+            lookupAddress
+        );
+        assembly {
+            return(add(v, 32), mload(v))
+        }
+    }
+
+    function reverseWithGatewaysCallback(bytes memory ccip, bytes memory addr0)
+        external
+        view
+        returns (string memory name, address resolver, address reverseResolver)
+    {
+        (Lookup memory rev, Lookup memory fwd, bytes memory addr) = abi.decode(ccip, (Lookup, Lookup, bytes));
+        if (keccak256(addr0) != keccak256(addr)) {
+            revert ReverseAddressMismatch(addr);
+        }
+        name = DNSCoder.decode(fwd.dns); // wont fail
+        resolver = fwd.resolver;
+        reverseResolver = _extractResolver(rev);
+    }
+
+    function _extractResolver(Lookup memory lookup) internal view returns (address resolver) {
+        resolver = lookup.resolver;
+        if (resolver == address(0)) {
+            revert ResolverNotFound(lookup.dns);
+        }
+        if (resolver.code.length == 0) {
+            revert ResolverNotContract(lookup.dns);
+        }
+    }
+
+    // ENSIP10ResolverFinder
+    function findResolver(bytes calldata name)
+        external
+        view
+        returns (address resolver, bytes32 namehash, uint256 finalOffset)
+    {
+        Lookup memory lookup = rr.ur().lookupName(name);
+        resolver = lookup.resolver;
+        namehash = lookup.node;
+        finalOffset = lookup.offset;
+    }
+}

--- a/test/SUPwithUniversalResolver.t.sol
+++ b/test/SUPwithUniversalResolver.t.sol
@@ -88,9 +88,6 @@ contract ProxyTest is Test {
     }
 
     function test_SuccessfulUpgradeToV3() public {
-        string[] memory urls = new string[](1);
-        urls[0] = "https://test1";
-
         bytes memory initDataV3 = abi.encodeWithSelector(UniversalResolverV3.initialize.selector, ens);
         vm.prank(ADMIN);
         proxy.upgradeToAndCall(address(urV3), initDataV3);

--- a/test/SUPwithUniversalResolver.t.sol
+++ b/test/SUPwithUniversalResolver.t.sol
@@ -6,6 +6,7 @@ import "../src/SingleTimeUpgradableProxy.sol";
 
 import {UniversalResolver as UniversalResolverV1} from "../src/mocks/UniversalResolverV1.sol";
 import {UniversalResolver as UniversalResolverV2} from "../src/mocks/UniversalResolverV2.sol";
+import {UniversalResolver as UniversalResolverV3} from "../src/mocks/UniversalResolverV3.sol";
 
 import {ENS} from "@ens-contracts-urv3/contracts/registry/ENS.sol";
 
@@ -17,6 +18,7 @@ contract ProxyTest is Test {
     SingleTimeUpgradableProxy proxy;
     UniversalResolverV1 urV1;
     UniversalResolverV2 urV2;
+    UniversalResolverV3 urV3;
 
     ENS ens = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
@@ -26,6 +28,7 @@ contract ProxyTest is Test {
 
         urV1 = new UniversalResolverV1();
         urV2 = new UniversalResolverV2();
+        urV3 = new UniversalResolverV3();
 
         bytes memory initData = abi.encodeWithSelector(UniversalResolverV1.initialize.selector, ens, urls);
         vm.prank(ADMIN);
@@ -55,12 +58,13 @@ contract ProxyTest is Test {
     }
 
     /////// Upgrade Tests ///////
-    function test_SuccessfulUpgrade() public {
+    function test_SuccessfulUpgradeToV2() public {
         string[] memory urls = new string[](1);
         urls[0] = "https://test1";
-        bytes memory initData = abi.encodeWithSelector(UniversalResolverV1.initialize.selector, ens, urls);
+
+        bytes memory initDataV2 = abi.encodeWithSelector(UniversalResolverV2.initialize.selector, ens, urls);
         vm.prank(ADMIN);
-        proxy.upgradeToAndCall(address(urV2), initData);
+        proxy.upgradeToAndCall(address(urV2), initDataV2);
 
         assertEq(proxy.implementation(), address(urV2));
         assertEq(proxy.admin(), address(0));
@@ -81,6 +85,32 @@ contract ProxyTest is Test {
         vm.prank(ADMIN);
         upgraded.setUrls(urls);
         assertEq(upgraded._urls(0), urls[0]);
+    }
+
+    function test_SuccessfulUpgradeToV3() public {
+        string[] memory urls = new string[](1);
+        urls[0] = "https://test1";
+
+        bytes memory initDataV3 = abi.encodeWithSelector(UniversalResolverV3.initialize.selector, ens);
+        vm.prank(ADMIN);
+        proxy.upgradeToAndCall(address(urV3), initDataV3);
+
+        assertEq(proxy.implementation(), address(urV3));
+        assertEq(proxy.admin(), address(0));
+
+        UniversalResolverV3 upgraded = UniversalResolverV3(address(proxy));
+
+        console.log("urV3 - owner");
+        console.logAddress(urV3.owner());
+        console.log("urV3 - address");
+        console.logAddress(address(urV3));
+        console.log("implementation address");
+        console.logAddress(proxy.implementation());
+        console.log("upgraded - owner");
+        console.logAddress(upgraded.owner());
+
+        vm.prank(ADMIN);
+        assertEq(proxy.implementation(), address(urV3));
     }
 
     function test_StoragePersistanceAfterUpgrade() public {


### PR DESCRIPTION
There are couple of changes needed on both UniversalResolver implementations before proceeding further;

- Storage Layout of current Universal Resolver and the new implementation doesn't match.
While current storage layout of Universal Resolver is;

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| 0   | _owner             | address     | (From Ownable) |
| 1    | batchGatewayURLs   | string[]    | |
| 2    | registry           | address     | |

For universal v3;

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| 0    | _rr           |  IReverseUR | |

which causes a storage collusion.


- Ownable module is incompatible with the Upgradable pattern

It sets the ownership at deployment time, while the implementation storage keeps the owner info, the proxy storage doesn't have access to same information. instead I used OwnableUpgradable, we can decouple the initialization, allow proxy to set ownership in proxy storage.

Both issues are addressed in the pull request. New storage layout;

### UniversalResolver V1

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| [INITIALIZABLE](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/930598edfb6241a179ade6ad44ba59ed8b68f7d8/contracts/proxy/utils/Initializable.sol#L77C30-L77C51) | _initialized       | uint8       | (From Initializable) |
| [OWNABLE](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/8ab1f5acf958b937531cee87f99ae4c0242f0dee/contracts/access/OwnableUpgradeable.sol#L28) | _owner             | address     | (From OwnableUpgradeable) |
| 0    | registry           | address     |  |
| 1    | batchGatewayURLs   | string[]    | |


### UniversalResolver V3

| Slot | Variable           | Type        | Note        |
|------|--------------------|-------------|-------------|
| [INITIALIZABLE](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/930598edfb6241a179ade6ad44ba59ed8b68f7d8/contracts/proxy/utils/Initializable.sol#L77C30-L77C51) | _initialized       | uint8       | (From Initializable) |
| [OWNABLE](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/8ab1f5acf958b937531cee87f99ae4c0242f0dee/contracts/access/OwnableUpgradeable.sol#L28) | _owner             | address     | (From OwnableUpgradeable) as future proof and storage layout match  |
| 0   | _rr  |  IReverseUR | |
| 1    | __urls   | string[]    | reserved as a removal |


### Test deployment (Sepolia)
| Contract | Address |
| --- | --- |
| <b>SUP</b> | 0xd802b69dfc7401ba4bd5db965ba5628a87a21894 |
| <b>UR</b> | 0xa7d88c515c60ba5e86461775b642b0877b34b6f2 |
| <b>ReverseUR</b> | 0x94545502b9e99a9bd1903f2a1fb8c5c121bef14c |
| <b>UniversalResolver V1</b> | 0xfd2be9a27377aa1675106f9d162f5824531a8542 | 
| <b>UniversalResolverV3</b> | 0x53BBac4816b203c87FbF44Ca79fB5Da6883EC7E9 |

upgrade tx:  https://sepolia.etherscan.io/tx/0xc711e9a95dfc5ca504ceb5b8a92825a8986d6db301bd2101ab0a9c661529b8e0
